### PR TITLE
Update global index behavior in documentations and messages in UI

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -127,6 +127,7 @@ The `Model` component,
 * stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * uses global index numbers for index-based commands; these numbers are based on the full player list and stay the same after `find`/`filter`.
+* rationale for global indices: keeping indices stable across filtered and unfiltered views avoids target-shift ambiguity in multi-step workflows (e.g. filter -> compare/edit/draft), where users can continue using the same index references without re-numbering.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -127,7 +127,7 @@ The `Model` component,
 * stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * uses global index numbers for index-based commands; these numbers are based on the full player list and stay the same after `find`/`filter`.
-* rationale for global indices: keeping indices stable across filtered and unfiltered views avoids target-shift ambiguity in multi-step workflows (e.g. filter -> compare/edit/draft), where users can continue using the same index references without re-numbering.
+* rationale for global indices: keeping indices stable across filtered and unfiltered views avoids ambiguity in multi-step workflows (e.g. filter -> compare/edit/draft), where users can continue using the same index references without re-numbering.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -126,7 +126,7 @@ The `Model` component,
 
 * stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
-* uses global index numbers for index-based commands; these indices are based on the full address book and are preserved when the displayed list is filtered.
+* uses global index numbers for index-based commands; these numbers are based on the full player list and stay the same after `find`/`filter`.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -126,6 +126,7 @@ The `Model` component,
 
 * stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
+* uses global index numbers for index-based commands; these indices are based on the full address book and are preserved when the displayed list is filtered.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,8 +77,8 @@ First time using this app? Consider going through the [walkthrough](#walkthrough
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* In this guide, `INDEX` means the global index number shown beside each player in the list.<br>
-  These index numbers are based on the full address book and remain the same in filtered views.
+* In this guide, `INDEX` means the index number shown beside each player in the list.<br>
+  These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
@@ -131,7 +131,8 @@ Deletes the specified person from the player list.
 Format: `delete INDEX`
 
 * Deletes the person at the specified `INDEX`.
-* The index refers to the global index number shown in the list (based on the full address book, including filtered views).
+* The index refers to the index number shown beside each player in the list.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 #### Editing a person : `edit`
@@ -140,7 +141,8 @@ Edits an existing person in the player list.
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`
 
-* Edits the person at the specified `INDEX`. The index refers to the global index number shown in the list (based on the full address book, including filtered views).
+* Edits the person at the specified `INDEX`. The index refers to the index number shown beside each player in the list.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
@@ -173,6 +175,8 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
 * Only full words will be matched e.g. `Han` will not match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* Changes which players are displayed, but the index numbers stay the same.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 
 Examples:
 * `find John` returns `john` and `John Doe`
@@ -190,7 +194,8 @@ Format: `filter [t/KEYWORD [MORE_KEYWORDS]...] [r/KEYWORD [MORE_KEYWORDS]...] [e
 * Within each category (tags, roles, entities), persons matching at least one keyword will be returned (i.e. `OR` search).
 * Multiple categories are combined with `AND` logic - a person must match at least one keyword from each specified category.
 * Only full words will be matched e.g. `friend` will not match `friends`
-* Filtering changes which players are displayed, but the displayed index numbers remain global indices based on the full address book.
+* Changes which players are displayed, but the index numbers stay the same.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 
 Examples:
 * `filter t/friend` Returns people tagged with `friend`
@@ -207,7 +212,8 @@ Compares two players identified by their index numbers.
 Format: `compare (INDEX1 | i/IGN1) (INDEX2 | i/IGN2)`
 
 * Displays details of both players side by side.
-* The indices refer to the global index numbers shown in the list (based on the full address book, including filtered views).
+* The indices refer to the index numbers shown beside each player in the list.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * Indices **must be positive integers** 1, 2, 3, …​
 * The two players must be different.
 
@@ -222,7 +228,8 @@ Tests if a specific team composition is valid.
 Format: `draft (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN)​`
 
 * Selects 5 players by their index numbers or in-game names (IGN).
-* If an index is used, it refers to the global index number shown in the list (based on the full address book, including filtered views).
+* If an index is used, it refers to the index number shown beside each player in the list.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * A valid team requires exactly 5 players with one player per role (TOP, JUNGLE, MID, BOT, SUPPORT).
 * You can mix indices and IGNs in the same command.
 * The `i/` prefix can optionally be omitted for non-numeric IGNs (e.g., `PlayerA` instead of `i/PlayerA`).
@@ -242,7 +249,8 @@ Updates the statistics of a player for a specific entity.
 
 Format: `stats (INDEX | i/IGN) ent/ENTITY [k/KILLS] [d/DEATHS] [a/ASSISTS]`
 
-* Updates the person at the specified `INDEX`, or with the specified IGN. The index refers to the global index number shown in the list (based on the full address book, including filtered views).
+* Updates the person at the specified `INDEX`, or with the specified IGN. The index refers to the index number shown beside each player in the list.
+* These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * The index **must be a positive integer** 1, 2, 3, …​
 * `ent/ENTITY` is required and specifies which champion the statistics are for.
 * At least one of the statistics fields (kills, deaths, assists) must be provided.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,6 +77,9 @@ First time using this app? Consider going through the [walkthrough](#walkthrough
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
+* In this guide, `INDEX` means the global index number shown beside each player in the list.<br>
+  These index numbers are based on the full address book and remain the same in filtered views.
+
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
@@ -128,7 +131,7 @@ Deletes the specified person from the player list.
 Format: `delete INDEX`
 
 * Deletes the person at the specified `INDEX`.
-* The index refers to the index number shown in the displayed person list.
+* The index refers to the global index number shown in the list (based on the full address book, including filtered views).
 * The index **must be a positive integer** 1, 2, 3, …​
 
 #### Editing a person : `edit`
@@ -137,7 +140,8 @@ Edits an existing person in the player list.
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`
 
-* Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
+* Edits the person at the specified `INDEX`. The index refers to the global index number shown in the list (based on the full address book, including filtered views).
+* The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
@@ -186,6 +190,7 @@ Format: `filter [t/KEYWORD [MORE_KEYWORDS]...] [r/KEYWORD [MORE_KEYWORDS]...] [e
 * Within each category (tags, roles, entities), persons matching at least one keyword will be returned (i.e. `OR` search).
 * Multiple categories are combined with `AND` logic - a person must match at least one keyword from each specified category.
 * Only full words will be matched e.g. `friend` will not match `friends`
+* Filtering changes which players are displayed, but the displayed index numbers remain global indices based on the full address book.
 
 Examples:
 * `filter t/friend` Returns people tagged with `friend`
@@ -202,7 +207,7 @@ Compares two players identified by their index numbers.
 Format: `compare (INDEX1 | i/IGN1) (INDEX2 | i/IGN2)`
 
 * Displays details of both players side by side.
-* The indices refer to the index numbers shown in the displayed person list.
+* The indices refer to the global index numbers shown in the list (based on the full address book, including filtered views).
 * Indices **must be positive integers** 1, 2, 3, …​
 * The two players must be different.
 
@@ -217,6 +222,7 @@ Tests if a specific team composition is valid.
 Format: `draft (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN)​`
 
 * Selects 5 players by their index numbers or in-game names (IGN).
+* If an index is used, it refers to the global index number shown in the list (based on the full address book, including filtered views).
 * A valid team requires exactly 5 players with one player per role (TOP, JUNGLE, MID, BOT, SUPPORT).
 * You can mix indices and IGNs in the same command.
 * The `i/` prefix can optionally be omitted for non-numeric IGNs (e.g., `PlayerA` instead of `i/PlayerA`).
@@ -236,7 +242,8 @@ Updates the statistics of a player for a specific entity.
 
 Format: `stats (INDEX | i/IGN) ent/ENTITY [k/KILLS] [d/DEATHS] [a/ASSISTS]`
 
-* Updates the person at the specified `INDEX`, or with the specified IGN. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
+* Updates the person at the specified `INDEX`, or with the specified IGN. The index refers to the global index number shown in the list (based on the full address book, including filtered views).
+* The index **must be a positive integer** 1, 2, 3, …​
 * `ent/ENTITY` is required and specifies which champion the statistics are for.
 * At least one of the statistics fields (kills, deaths, assists) must be provided.
 * Existing statistics for the entity will be added to the new values.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,6 +17,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_GLOBAL_INDEX_CUE = "Note: The displayed index is a global index based on "
+            + "the full player list; find/filter changes visibility only and does not renumber indices.";
+    public static final String MESSAGE_GLOBAL_INDEX_COMMAND_CUE = "Note: This command interprets index inputs as "
+            + "global indices from the full player list.";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/CompareCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompareCommand.java
@@ -20,7 +20,7 @@ public class CompareCommand extends Command {
 
     public static final String MESSAGE_USAGE =
             "Compares two players identified by their index numbers"
-            + " or in-game names (IGNs) in the displayed person list.";
+            + " or in-game names (IGNs).";
 
     public static final String PARAMETERS =
         "Parameters: INDEX1 INDEX2 or i/IGN1 i/IGN2 or combinations (must be two different identifiers)\n";
@@ -59,7 +59,8 @@ public class CompareCommand extends Command {
         }
 
         return new CommandResult(
-                String.format(MESSAGE_COMPARE_SUCCESS, Messages.format(person1), Messages.format(person2)),
+            String.format(MESSAGE_COMPARE_SUCCESS, Messages.format(person1), Messages.format(person2))
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE,
                 false, false, true, person1, person2
         );
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -19,7 +19,7 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE =
-        "Deletes the person identified by the index number or in-game name (IGN) used in the displayed person list.";
+        "Deletes the person identified by the index number or in-game name (IGN).";
 
     public static final String PARAMETERS = "Parameters: INDEX (must be a positive integer) or i/IGN\n";
 
@@ -46,7 +46,8 @@ public class DeleteCommand extends Command {
         Person personToDelete = CommandUtil.findPersonByIdentifier(addressBookList, targetIdentifier);
 
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete))
+            + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DraftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DraftCommand.java
@@ -96,7 +96,8 @@ public class DraftCommand extends Command {
 
         // Validate composition and generate result message
         String validationMessage = generateValidationMessage(selectedPlayers);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, validationMessage),
+        return new CommandResult(String.format(MESSAGE_SUCCESS, validationMessage)
+            + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE,
                 false, false, false, null, null, true, selectedPlayers);
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -42,7 +42,7 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = "Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+            + "by the index number used in the list. "
             + "Existing values will be overwritten by the input values.";
 
     public static final String PARAMETERS = "Parameters: INDEX (must be a positive integer) "
@@ -98,7 +98,8 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson))
+            + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -38,7 +38,8 @@ public class FilterCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+            String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size())
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_CUE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,7 +33,8 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+            String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size())
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_CUE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -29,7 +29,7 @@ public class StatsCommand extends Command {
     public static final String COMMAND_WORD = "stats";
 
     public static final String MESSAGE_USAGE = "Updates the statistics of the person identified "
-            + "by the index number used in the displayed person list. "
+            + "by the index number used in the list. "
             + "Existing values will be overwritten by the input values.";
 
     public static final String PARAMETERS = "Parameters: INDEX (must be a positive integer) "
@@ -74,7 +74,8 @@ public class StatsCommand extends Command {
         Person editedPerson = createStatsEditedPerson(personToEdit, editStatsDescriptor);
 
         model.setPerson(personToEdit, editedPerson);
-        return new CommandResult(String.format(MESSAGE_STATS_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_STATS_SUCCESS, Messages.format(editedPerson))
+            + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -39,7 +39,8 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_IDENTIFIER =
-        "Invalid identifier. Must be either a positive integer index or an IGN prefixed with 'i/'.";
+        "Invalid identifier. Must be either a global positive integer index shown beside a player in the list "
+            + "or an IGN prefixed with 'i/'.";
     public static final String MESSAGE_INVALID_STATISTICS_FORMAT =
         "Invalid statistics. The format of statistics is s/kills-deaths-assists";
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -25,6 +25,8 @@ import seedu.address.logic.commands.CommandRegistry;
 public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-w09-2.github.io/tp/UserGuide.html";
+    public static final String GLOBAL_INDEX_HELP_RULE = "Note: The displayed index is a global index based on the "
+        + "full player list; find/filter changes visibility only and does not renumber indices.";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -51,7 +53,7 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow(Stage root) {
         super(FXML, root);
-        urlLabel.setText("Refer to the user guide: " + USERGUIDE_URL);
+        urlLabel.setText(GLOBAL_INDEX_HELP_RULE + "\n" + "Refer to the user guide: " + USERGUIDE_URL);
         setupCommandTable();
     }
 

--- a/src/test/java/seedu/address/logic/commands/CompareCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompareCommandTest.java
@@ -33,7 +33,8 @@ public class CompareCommandTest {
         CompareCommand compareCommand = new CompareCommand("1", "2");
 
         String expectedMessage = String.format(CompareCommand.MESSAGE_COMPARE_SUCCESS,
-                Messages.format(person1), Messages.format(person2));
+            Messages.format(person1), Messages.format(person2));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, true, person1, person2);
         assertCommandSuccess(compareCommand, model, expectedCommandResult, model);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -32,7 +32,8 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand("1");
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+            Messages.format(personToDelete));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -56,7 +57,8 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand("1");
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+            Messages.format(personToDelete));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -76,7 +78,8 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand("2");
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+            Messages.format(personToDelete));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
@@ -93,8 +93,8 @@ public class DraftCommandTest {
                 + "Composition: TOP (2) | JUNGLE (0) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I\n"
                 + "Issues: Too many TOP players, Missing JUNGLE player";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
-                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, draftPlayers);
 
@@ -136,8 +136,8 @@ public class DraftCommandTest {
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
-                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, draftPlayers);
 
@@ -165,8 +165,8 @@ public class DraftCommandTest {
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
-                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, expectedDraftPlayers);
 

--- a/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -64,6 +65,7 @@ public class DraftCommandTest {
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I";
         String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, draftPlayers);
 
@@ -91,7 +93,8 @@ public class DraftCommandTest {
                 + "Composition: TOP (2) | JUNGLE (0) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I\n"
                 + "Issues: Too many TOP players, Missing JUNGLE player";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, draftPlayers);
 
@@ -133,7 +136,8 @@ public class DraftCommandTest {
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, draftPlayers);
 
@@ -161,7 +165,8 @@ public class DraftCommandTest {
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
                 + "Average Rank: GOLD I";
-        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation);
+        String expectedMessage = String.format(DraftCommand.MESSAGE_SUCCESS, expectedValidation)
+                + "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false, false, null, null,
                 true, expectedDraftPlayers);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -42,6 +42,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand("1", descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(
@@ -66,6 +67,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(indexLastPersonStr, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
@@ -79,6 +81,7 @@ public class EditCommandTest {
         Person editedPerson = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -95,6 +98,7 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(
@@ -151,6 +155,7 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -62,8 +62,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_tagFilter_filtersPersonsByTag() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
-            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        expectedMessage += "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareTagPredicate("friends owesMoney");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -72,8 +72,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_roleFilter_filtersPersonsByRole() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2)
-            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        expectedMessage += "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareRolePredicate("jungle");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,8 +82,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_combinedFilter_filtersPersonsByTagAndRole() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1)
-            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        expectedMessage += "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareCombinedPredicate("friends", "jungle");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_GLOBAL_INDEX_CUE;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -61,7 +62,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_tagFilter_filtersPersonsByTag() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
+            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareTagPredicate("friends owesMoney");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -70,7 +72,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_roleFilter_filtersPersonsByRole() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2)
+            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareRolePredicate("jungle");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -79,7 +82,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_combinedFilter_filtersPersonsByTagAndRole() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1)
+            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         CompositePredicate predicate = prepareCombinedPredicate("friends", "jungle");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_GLOBAL_INDEX_CUE;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.CARL;
@@ -56,7 +57,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -66,7 +68,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
+            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -57,8 +57,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
-            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        expectedMessage += "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -68,8 +68,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
-            + "\n" + MESSAGE_GLOBAL_INDEX_CUE;
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        expectedMessage += "\n" + MESSAGE_GLOBAL_INDEX_CUE;
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/StatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StatsCommandTest.java
@@ -49,6 +49,7 @@ public class StatsCommandTest {
         StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
@@ -73,6 +74,7 @@ public class StatsCommandTest {
         StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
@@ -101,6 +103,7 @@ public class StatsCommandTest {
         StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
+        expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);


### PR DESCRIPTION
Add global index numbers to Features and to every command that accepts indices in UG.
Add rationale to DG.

Update `The index refers to the index number shown *in the displayed person list*` to `The index refers to the index number shown *beside each player in the list*` in UG

Add `Note: This command interprets index inputs as global indices from the full player list` to success message of `Find` and `Filter`

Add `Note: The displayed index is a global index based on the full player list; find/filter changes visibility only and does not renumber indices` to success message of commands that accept indices, and `Help` window