### PR TITLE
Standardize all commands to use Index | IGN

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -379,7 +379,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. User <ins>lists all players (UC10)</ins>.
-2. User requests to edit a specific player by index with one or more fields.
+2. User requests to edit a specific player by index or IGN with one or more fields.
 3. DraftDeck updates the player and shows a success message.
 
    Use case ends.
@@ -676,6 +676,9 @@ testers are expected to do more *exploratory* testing.
    1. Test case: `delete 1`<br>
       Expected: First player is deleted from the list. Details of the deleted player shown in the status message.
 
+   1. Test case: `delete i/PlayerName` (assuming PlayerName exists)<br>
+      Expected: The player with IGN "PlayerName" is deleted from the list.
+
 1. Editing players
 
    1. Prerequisites: List all players using the `list` command.
@@ -685,6 +688,9 @@ testers are expected to do more *exploratory* testing.
 
    1. Test case: `edit 2 n/Betsy Crower t/`<br>
       Expected: Second player's name is updated and all tags are cleared.
+
+   1. Test case: `edit i/PlayerName r/BOT` (assuming PlayerName exists)<br>
+      Expected: The player with IGN "PlayerName" has their role updated to BOT.
 
 1. Listing all players
 
@@ -741,6 +747,9 @@ testers are expected to do more *exploratory* testing.
 
    1. Test case: `stats 1 ent/Ahri k/10` (adding to existing stats)<br>
       Expected: Player 1's Ahri kills are increased by 10 (cumulative).
+
+   1. Test case: `stats i/PlayerName ent/Ahri k/50 d/10 a/20` (assuming PlayerName exists)<br>
+      Expected: Player with IGN "PlayerName" has their Ahri statistics updated.
 
 1. Adding match results
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,20 +134,25 @@ Examples:
 
 Deletes the specified player from the player list.
 
-Format: `delete INDEX`
+Format: `delete (INDEX | i/IGN)`
 
-* Deletes the player at the specified `INDEX`.
+* Deletes the player at the specified `INDEX`, or with the specified `IGN`.
 * The index refers to the index number shown beside each player in the list.
 * These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * The index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+* `delete 3` Deletes the 3rd player in the list.
+* `delete i/PlayerName` Deletes the player with IGN "PlayerName".
 
 #### Editing a player : `edit`
 
 Edits an existing player in the player list.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`
+Format: `edit (INDEX | i/IGN) [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`
 
-* Edits the player at the specified `INDEX`. The index refers to the index number shown beside each player in the list.
+* Edits the player at the specified `INDEX`, or with the specified `IGN`.
+* The index refers to the index number shown beside each player in the list.
 * These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -160,6 +165,7 @@ Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st player to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd player to be `Betsy Crower` and clears all existing tags.
 *  `edit 3 r/JUNGLE rank/DIAMOND I` Edits the role and rank of the 3rd player.
+*  `edit i/PlayerName r/BOT` Edits the role of the player with IGN "PlayerName" to BOT.
 
 #### Listing all players : `list`
 
@@ -241,7 +247,6 @@ Format: `draft (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (
 * If an index is used, it refers to the index number shown beside each player in the list.
 * These numbers are global: they are based on the full player list and stay the same after `find`/`filter`.
 * You can mix indices and IGNs in the same command.
-* The `i/` prefix can optionally be omitted for non-numeric IGNs (e.g., `PlayerA` instead of `i/PlayerA`).
 * A valid team composition has exactly one player per role (TOP, JUNGLE, MID, BOT, SUPPORT).
 * Invalid role compositions are not rejected; instead, DraftDeck displays diagnostic messages (e.g., missing roles, duplicate roles).
 
@@ -249,7 +254,6 @@ Examples:
 * `draft 1 2 3 4 5` Drafts players at indices 1-5.
 * `draft i/PlayerA i/PlayerB i/PlayerC i/PlayerD i/PlayerE` Drafts players by their IGNs.
 * `draft 1 2 i/CarlK77 4 i/ElleM55` Mixes indices and IGNs.
-* `draft 1 2 CarlK77 4 ElleM55` Alternative syntax with the `i/` prefix omitted for non-numeric IGNs.
 
 Example output:
 ![Sample output for valid composition](images/draftSuccess.png)
@@ -336,17 +340,17 @@ Action | Format, Examples
 --------|------------------
 **Add** | `add n/NAME p/PHONE e/EMAIL i/IGN r/ROLE rank/RANK [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com i/JamesH88 r/BOT rank/PLATINUM I t/friend t/colleague`
 **Clear** | `clear`
-**Compare** | `compare INDEX1 INDEX2`<br> e.g., `compare 1 2`
-**Delete** | `delete INDEX`<br> e.g., `delete 3`
+**Compare** | `compare (INDEX1 \| i/IGN1) (INDEX2 \| i/IGN2)`<br> e.g., `compare 1 2` or `compare i/Alex 2`
+**Delete** | `delete (INDEX \| i/IGN)`<br> e.g., `delete 3` or `delete i/PlayerName`
 **Draft** | `draft (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN)`<br> e.g., `draft 1 2 i/CarlK77 4 i/ElleM55`
-**Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee r/JUNGLE rank/GOLD`
+**Edit** | `edit (INDEX \| i/IGN) [n/NAME] [p/PHONE] [e/EMAIL] [i/IGN] [r/ROLE] [rank/RANK] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee r/JUNGLE rank/GOLD` or `edit i/PlayerName r/BOT`
 **Exit** | `exit`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **Filter** | `filter [t/KEYWORD [MORE_KEYWORDS]...] [r/KEYWORD [MORE_KEYWORDS]...] [ent/KEYWORD [MORE_KEYWORDS]...]`<br> e.g., `filter t/pro r/bot ent/Jinx`
 **Help** | `help`
 **List** | `list`
 **Result** | `result w/RESULT [date/yyyy-MM-dd] i/IGN ent/ENTITY s/KILLS-DEATHS-ASSISTS`<br> e.g., `result w/WIN i/AlexY42 ent/Ahri s/10-2-8 i/Bern_Storm ent/Leona s/1-1-12 i/Charlie99 ent/Evelynn s/5-6-15 i/DavidLi91 ent/Irelia s/2-19-4 i/IrfanZ ent/Kayn s/6-3-8`
-**Stats** | `stats INDEX ent/ENTITY [k/KILLS] [d/DEATHS] [a/ASSISTS]`<br> e.g., `stats 1 ent/Ahri k/50 d/10 a/20`
+**Stats** | `stats (INDEX \| i/IGN) ent/ENTITY [k/KILLS] [d/DEATHS] [a/ASSISTS]`<br> e.g., `stats 1 ent/Ahri k/50 d/10 a/20` or `stats i/PlayerName ent/Ahri k/50`
 
 
 ### Glossary

--- a/src/main/java/seedu/address/logic/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/CommandUtil.java
@@ -19,6 +19,17 @@ public class CommandUtil {
      * @throws CommandException if the identifier is invalid (out of bounds index or IGN not found)
      */
     public static Person findPersonByIdentifier(List<Person> personList, String identifier) throws CommandException {
+        // Check if identifier is an IGN with i/ prefix
+        if (identifier.startsWith("i/")) {
+            String ign = identifier.substring(2);
+            for (Person person : personList) {
+                if (person.getIgn().value.equalsIgnoreCase(ign)) {
+                    return person;
+                }
+            }
+            throw new CommandException(String.format("Player with IGN '%1$s' not found", ign));
+        }
+
         // Check if identifier is an index (numeric)
         if (identifier.matches("\\d+")) {
             int index = Integer.parseInt(identifier) - 1; // Convert to zero-based
@@ -26,14 +37,14 @@ public class CommandUtil {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
             return personList.get(index);
-        } else {
-            // It's an IGN
-            for (Person person : personList) {
-                if (person.getIgn().value.equalsIgnoreCase(identifier)) {
-                    return person;
-                }
-            }
-            throw new CommandException(String.format("Player with IGN '%1$s' not found", identifier));
         }
+
+        // Fallback: treat as IGN (for backward compatibility)
+        for (Person person : personList) {
+            if (person.getIgn().value.equalsIgnoreCase(identifier)) {
+                return person;
+            }
+        }
+        throw new CommandException(String.format("Player with IGN '%1$s' not found", identifier));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DraftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DraftCommand.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.CommandUtil;
 import seedu.address.logic.Messages;
@@ -42,20 +41,17 @@ public class DraftCommand extends Command {
     private static final int REQUIRED_TEAM_SIZE = 5;
     private static final int REQUIRED_PLAYERS_PER_ROLE = 1;
 
-    private final List<Index> indices;
-    private final List<String> igns;
+    private final List<String> identifiers;
 
     /**
-     * Creates a DraftCommand with the specified player indices and IGNs.
+     * Creates a DraftCommand with the specified player identifiers.
+     * Each identifier is either a numeric index or an IGN prefixed with 'i/'.
      *
-     * @param indices list of indices of players to draft (may be empty)
-     * @param igns list of in-game names of players to draft (may be empty)
+     * @param identifiers list of identifiers for players to draft
      */
-    public DraftCommand(List<Index> indices, List<String> igns) {
-        requireNonNull(indices);
-        requireNonNull(igns);
-        this.indices = new ArrayList<>(indices);
-        this.igns = new ArrayList<>(igns);
+    public DraftCommand(List<String> identifiers) {
+        requireNonNull(identifiers);
+        this.identifiers = new ArrayList<>(identifiers);
     }
 
     @Override
@@ -63,20 +59,11 @@ public class DraftCommand extends Command {
         requireNonNull(model);
         List<Person> addressBookList = model.getAddressBook().getPersonList();
 
-        // Resolve all players from both indices and IGNs
+        // Resolve all players from identifiers
         List<Person> selectedPlayers = new ArrayList<>();
 
-        // Resolve indices
-        for (Index index : indices) {
-            if (index.getZeroBased() >= addressBookList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
-            selectedPlayers.add(addressBookList.get(index.getZeroBased()));
-        }
-
-        // Resolve IGNs
-        for (String ign : igns) {
-            selectedPlayers.add(CommandUtil.findPersonByIdentifier(addressBookList, ign));
+        for (String identifier : identifiers) {
+            selectedPlayers.add(CommandUtil.findPersonByIdentifier(addressBookList, identifier));
         }
 
         // Check for exactly 5 unique players
@@ -207,14 +194,13 @@ public class DraftCommand extends Command {
         }
 
         DraftCommand otherDraftCommand = (DraftCommand) other;
-        return indices.equals(otherDraftCommand.indices) && igns.equals(otherDraftCommand.igns);
+        return identifiers.equals(otherDraftCommand.identifiers);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("indices", indices)
-                .add("igns", igns)
+                .add("identifiers", identifiers)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -42,10 +42,10 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = "Edits the details of the person identified "
-            + "by the index number used in the list. "
+            + "by the index number or IGN. "
             + "Existing values will be overwritten by the input values.";
 
-    public static final String PARAMETERS = "Parameters: INDEX (must be a positive integer) "
+    public static final String PARAMETERS = "Parameters: (INDEX | i/IGN) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -9,8 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_KILLS;
 import java.util.List;
 import java.util.Optional;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.CommandUtil;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -29,10 +29,10 @@ public class StatsCommand extends Command {
     public static final String COMMAND_WORD = "stats";
 
     public static final String MESSAGE_USAGE = "Updates the statistics of the person identified "
-            + "by the index number used in the list. "
+            + "by the index number or IGN. "
             + "Existing values will be overwritten by the input values.";
 
-    public static final String PARAMETERS = "Parameters: INDEX (must be a positive integer) "
+    public static final String PARAMETERS = "Parameters: (INDEX | i/IGN) "
             + PREFIX_ENTITY + "ENTITY "
             + "[" + PREFIX_KILLS + "KILLS] "
             + "[" + PREFIX_DEATHS + "DEATHS] "
@@ -45,19 +45,18 @@ public class StatsCommand extends Command {
     public static final String MESSAGE_STATS_SUCCESS = "Updated Statistics for Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one statistics field to update must be provided.";
 
-    private final Index index;
+    private final String identifier;
     private final EditStatsDescriptor editStatsDescriptor;
 
     /**
-     * @param index               of the person in the filtered person list to
-     *                            update stats
+     * @param identifier          of the person (index or i/IGN) to update stats
      * @param editStatsDescriptor details to update the statistics with
      */
-    public StatsCommand(Index index, EditStatsDescriptor editStatsDescriptor) {
-        requireNonNull(index);
+    public StatsCommand(String identifier, EditStatsDescriptor editStatsDescriptor) {
+        requireNonNull(identifier);
         requireNonNull(editStatsDescriptor);
 
-        this.index = index;
+        this.identifier = identifier;
         this.editStatsDescriptor = new EditStatsDescriptor(editStatsDescriptor);
     }
 
@@ -66,11 +65,7 @@ public class StatsCommand extends Command {
         requireNonNull(model);
         List<Person> addressBookList = model.getAddressBook().getPersonList();
 
-        if (index.getZeroBased() >= addressBookList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-        }
-
-        Person personToEdit = addressBookList.get(index.getZeroBased());
+        Person personToEdit = CommandUtil.findPersonByIdentifier(addressBookList, identifier);
         Person editedPerson = createStatsEditedPerson(personToEdit, editStatsDescriptor);
 
         model.setPerson(personToEdit, editedPerson);
@@ -128,7 +123,7 @@ public class StatsCommand extends Command {
         }
 
         StatsCommand otherStatsCommand = (StatsCommand) other;
-        return index.equals(otherStatsCommand.index)
+        return identifier.equals(otherStatsCommand.identifier)
                 && editStatsDescriptor.equals(otherStatsCommand.editStatsDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/parser/DraftCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DraftCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_IGN;
 import java.util.ArrayList;
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DraftCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -32,25 +31,26 @@ public class DraftCommandParser implements Parser<DraftCommand> {
         }
 
         String[] argStrings = trimmedArgs.split("\\s+");
-        List<Index> indices = new ArrayList<>();
-        List<String> igns = new ArrayList<>();
+        List<String> identifiers = new ArrayList<>();
         String prefix = PREFIX_IGN.getPrefix();
 
         for (String argString : argStrings) {
+            // Handle i/ prefix: validate non-empty, then keep prefix intact
             if (argString.startsWith(prefix)) {
                 String ign = argString.substring(prefix.length());
                 if (ign.isEmpty()) {
                     throw new ParseException(MESSAGE_INVALID_IGN_EMPTY);
                 }
-                igns.add(ign);
-            } else if (!argString.matches("\\d+")) {
-                igns.add(argString);
+                identifiers.add(argString); // Keep i/ prefix intact
+            } else if (argString.matches("\\d+")) {
+                // Numeric index
+                identifiers.add(ParserUtil.parseIdentifier(argString));
             } else {
-                Index index = ParserUtil.parseIndex(argString);
-                indices.add(index);
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DraftCommand.PARAMETERS));
             }
         }
 
-        return new DraftCommand(indices, igns);
+        return new DraftCommand(identifiers);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -40,7 +40,7 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_IDENTIFIER =
         "Invalid identifier. Must be either a global positive integer index shown beside a player in the list "
-            + "or an IGN prefixed with 'i/'.";
+            + "or an IGN prefixed with 'i/' (e.g., i/PlayerName).";
     public static final String MESSAGE_INVALID_STATISTICS_FORMAT =
         "Invalid statistics. The format of statistics is s/kills-deaths-assists";
 
@@ -59,24 +59,25 @@ public class ParserUtil {
 
     /**
      * Parses {@code identifier} which can be either an index (numeric) or an IGN (prefixed with i/).
-     * Returns a string representation of the identifier.
+     * Returns a string representation of the identifier with the i/ prefix preserved for IGNs.
      *
      * @throws ParseException if the identifier format is invalid.
      */
     public static String parseIdentifier(String identifier) throws ParseException {
         String trimmed = identifier.trim();
 
-        // Check if it's a numeric index
-        if (StringUtil.isNonZeroUnsignedInteger(trimmed)) {
-            return trimmed;
-        }
-
-        // Check if it's an IGN with prefix
+        // Check if it's an IGN with prefix (check this FIRST so numeric IGNs work)
         if (trimmed.startsWith("i/")) {
             String ign = trimmed.substring(2);
             if (!ign.isEmpty()) {
-                return ign;
+                return trimmed; // Keep the i/ prefix intact
             }
+            throw new ParseException(MESSAGE_INVALID_IDENTIFIER);
+        }
+
+        // Check if it's a numeric index
+        if (StringUtil.isNonZeroUnsignedInteger(trimmed)) {
+            return trimmed;
         }
 
         throw new ParseException(MESSAGE_INVALID_IDENTIFIER);

--- a/src/main/java/seedu/address/logic/parser/StatsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatsCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DEATHS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ENTITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_KILLS;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StatsCommand;
 import seedu.address.logic.commands.StatsCommand.EditStatsDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -30,9 +29,9 @@ public class StatsCommandParser implements Parser<StatsCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
             args, PREFIX_ENTITY, PREFIX_KILLS, PREFIX_DEATHS, PREFIX_ASSISTS);
 
-        Index index;
+        String identifier;
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            identifier = ParserUtil.parseIdentifier(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatsCommand.PARAMETERS), pe);
         }
@@ -63,6 +62,6 @@ public class StatsCommandParser implements Parser<StatsCommand> {
             throw new ParseException(StatsCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new StatsCommand(index, editStatsDescriptor);
+        return new StatsCommand(identifier, editStatsDescriptor);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
@@ -34,25 +34,19 @@ public class DraftCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void constructor_nullIndices_throwsNullPointerException() {
+    public void constructor_nullIdentifiers_throwsNullPointerException() {
         seedu.address.testutil.Assert.assertThrows(NullPointerException.class, () ->
-                new DraftCommand(null, List.of()));
-    }
-
-    @Test
-    public void constructor_nullIgns_throwsNullPointerException() {
-        seedu.address.testutil.Assert.assertThrows(NullPointerException.class, () ->
-                new DraftCommand(List.of(), null));
+                new DraftCommand(null));
     }
 
     @Test
     public void execute_validDraft_success() {
         DraftCommand draftCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SECOND_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON,
-                INDEX_FIFTH_PERSON), List.of());
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SECOND_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                String.valueOf(INDEX_FOURTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_FIFTH_PERSON.getOneBased())));
 
         List<Person> draftPlayers = List.of(
                 model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
@@ -76,11 +70,11 @@ public class DraftCommandTest {
     @Test
     public void execute_invalidDraftComposition_successWithIssues() {
         DraftCommand draftCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SIXTH_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON,
-                INDEX_FIFTH_PERSON), List.of());
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SIXTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                String.valueOf(INDEX_FOURTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_FIFTH_PERSON.getOneBased())));
 
         List<Person> draftPlayers = List.of(
                 model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
@@ -105,17 +99,20 @@ public class DraftCommandTest {
     @Test
     public void execute_invalidPersonIndex_failure() {
         Index outOfBoundsIndex = Index.fromOneBased(model.getAddressBook().getPersonList().size() + 1);
-        DraftCommand draftCommand = new DraftCommand(List.of(INDEX_FIRST_PERSON, outOfBoundsIndex), List.of());
+        DraftCommand draftCommand = new DraftCommand(List.of(
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(outOfBoundsIndex.getOneBased())));
 
         assertCommandFailure(draftCommand, model, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_invalidIgn_failure() {
-        String invalidIgn = "InvalidName";
-        DraftCommand draftCommand = new DraftCommand(List.of(), List.of(invalidIgn));
+        String invalidIgn = "i/InvalidName";
+        DraftCommand draftCommand = new DraftCommand(List.of(invalidIgn));
 
-        assertCommandFailure(draftCommand, model, String.format(MESSAGE_INVALID_IGN_NOT_FOUND, invalidIgn));
+        assertCommandFailure(draftCommand, model,
+                String.format(MESSAGE_INVALID_IGN_NOT_FOUND, "InvalidName"));
     }
 
     @Test
@@ -127,11 +124,11 @@ public class DraftCommandTest {
                 model.getAddressBook().getPersonList().get(INDEX_FOURTH_PERSON.getZeroBased()),
                 model.getAddressBook().getPersonList().get(INDEX_FIFTH_PERSON.getZeroBased()));
 
-        List<String> ignList = draftPlayers.stream()
-                .map(person -> person.getIgn().value)
+        List<String> ignIdentifiers = draftPlayers.stream()
+                .map(person -> "i/" + person.getIgn().value)
                 .toList();
 
-        DraftCommand draftCommand = new DraftCommand(List.of(), ignList);
+        DraftCommand draftCommand = new DraftCommand(ignIdentifiers);
 
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
@@ -155,12 +152,17 @@ public class DraftCommandTest {
                 model.getAddressBook().getPersonList().get(INDEX_FOURTH_PERSON.getZeroBased()),
                 model.getAddressBook().getPersonList().get(INDEX_FIFTH_PERSON.getZeroBased()));
 
-        List<String> ignList = List.of(
-                expectedDraftPlayers.get(2).getIgn().value,
-                expectedDraftPlayers.get(3).getIgn().value,
-                expectedDraftPlayers.get(4).getIgn().value);
+        List<String> ignIdentifiers = List.of(
+                "i/" + expectedDraftPlayers.get(2).getIgn().value,
+                "i/" + expectedDraftPlayers.get(3).getIgn().value,
+                "i/" + expectedDraftPlayers.get(4).getIgn().value);
 
-        DraftCommand draftCommand = new DraftCommand(List.of(INDEX_FIRST_PERSON, INDEX_THIRD_PERSON), ignList);
+        DraftCommand draftCommand = new DraftCommand(List.of(
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                ignIdentifiers.get(0),
+                ignIdentifiers.get(1),
+                ignIdentifiers.get(2)));
 
         String expectedValidation = "\u2713 Draft Valid!\n"
                 + "Composition: TOP (1) | JUNGLE (1) | MID (1) | BOT (1) | SUPPORT (1)\n"
@@ -178,10 +180,10 @@ public class DraftCommandTest {
     public void execute_lessThanFivePlayers_failure() {
         // Only 4 players provided
         DraftCommand draftCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SECOND_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON), List.of());
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SECOND_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                String.valueOf(INDEX_FOURTH_PERSON.getOneBased())));
 
         assertCommandFailure(draftCommand, model, String.format(MESSAGE_INVALID_TEAM_SIZE, 4));
     }
@@ -190,12 +192,12 @@ public class DraftCommandTest {
     public void execute_moreThanFivePlayers_failure() {
         // 6 players provided
         DraftCommand draftCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SECOND_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON,
-                INDEX_FIFTH_PERSON,
-                INDEX_SIXTH_PERSON), List.of());
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SECOND_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                String.valueOf(INDEX_FOURTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_FIFTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_SIXTH_PERSON.getOneBased())));
 
         assertCommandFailure(draftCommand, model, String.format(MESSAGE_INVALID_TEAM_SIZE, 6));
     }
@@ -204,11 +206,11 @@ public class DraftCommandTest {
     public void execute_duplicatePlayer_failure() {
         // Same player selected twice using index
         DraftCommand draftCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SECOND_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON,
-                INDEX_FIRST_PERSON), List.of());
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SECOND_PERSON.getOneBased()),
+                String.valueOf(INDEX_THIRD_PERSON.getOneBased()),
+                String.valueOf(INDEX_FOURTH_PERSON.getOneBased()),
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased())));
 
         Person duplicatePlayer = model.getAddressBook().getPersonList()
                 .get(INDEX_FIRST_PERSON.getZeroBased());
@@ -218,16 +220,20 @@ public class DraftCommandTest {
 
     @Test
     public void equals() {
-        DraftCommand draftFirstCommand = new DraftCommand(List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON), List.of());
-        DraftCommand draftSecondCommand = new DraftCommand(List.of(INDEX_SECOND_PERSON, INDEX_THIRD_PERSON), List.of());
+        DraftCommand draftFirstCommand = new DraftCommand(
+                List.of(String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                        String.valueOf(INDEX_SECOND_PERSON.getOneBased())));
+        DraftCommand draftSecondCommand = new DraftCommand(
+                List.of(String.valueOf(INDEX_SECOND_PERSON.getOneBased()),
+                        String.valueOf(INDEX_THIRD_PERSON.getOneBased())));
 
         // same object -> returns true
         assertTrue(draftFirstCommand.equals(draftFirstCommand));
 
         // same values -> returns true
         DraftCommand draftFirstCommandCopy = new DraftCommand(
-                List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON),
-                List.of());
+                List.of(String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                        String.valueOf(INDEX_SECOND_PERSON.getOneBased())));
         assertTrue(draftFirstCommand.equals(draftFirstCommandCopy));
 
         // different types -> returns false
@@ -240,17 +246,18 @@ public class DraftCommandTest {
         assertFalse(draftFirstCommand.equals(draftSecondCommand));
 
         // hybrid commands with same values -> returns true
-        DraftCommand draftHybrid1 = new DraftCommand(List.of(INDEX_FIRST_PERSON), List.of("BensonM88"));
-        DraftCommand draftHybrid2 = new DraftCommand(List.of(INDEX_FIRST_PERSON), List.of("BensonM88"));
+        DraftCommand draftHybrid1 = new DraftCommand(
+                List.of(String.valueOf(INDEX_FIRST_PERSON.getOneBased()), "i/BensonM88"));
+        DraftCommand draftHybrid2 = new DraftCommand(
+                List.of(String.valueOf(INDEX_FIRST_PERSON.getOneBased()), "i/BensonM88"));
         assertTrue(draftHybrid1.equals(draftHybrid2));
 
         // indices-only vs IGNs-only -> returns false
         DraftCommand draftWithIndicesOnly = new DraftCommand(
-                List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON),
-                List.of());
+                List.of(String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                        String.valueOf(INDEX_SECOND_PERSON.getOneBased())));
         DraftCommand draftWithIgnsOnly = new DraftCommand(
-                List.of(),
-                List.of("AliceP99", "BensonM88"));
+                List.of("i/AliceP99", "i/BensonM88"));
         assertFalse(draftWithIndicesOnly.equals(draftWithIgnsOnly));
 
         // indices-only vs hybrid -> returns false
@@ -260,16 +267,18 @@ public class DraftCommandTest {
     @Test
     public void toStringMethod() {
         // test with indices only
-        List<Index> indices = List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
-        DraftCommand draftCommand = new DraftCommand(indices, List.of());
-        String expected = DraftCommand.class.getCanonicalName() + "{indices=" + indices + ", igns=[]}";
+        List<String> identifiers = List.of(
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.valueOf(INDEX_SECOND_PERSON.getOneBased()));
+        DraftCommand draftCommand = new DraftCommand(identifiers);
+        String expected = DraftCommand.class.getCanonicalName() + "{identifiers=" + identifiers + "}";
         assertEquals(expected, draftCommand.toString());
 
         // test with hybrid (indices and IGNs)
-        indices = List.of(INDEX_FIRST_PERSON);
-        List<String> igns = List.of("BensonM88", "CarlK77");
-        draftCommand = new DraftCommand(indices, igns);
-        expected = DraftCommand.class.getCanonicalName() + "{indices=" + indices + ", igns=" + igns + "}";
+        identifiers = List.of(
+                String.valueOf(INDEX_FIRST_PERSON.getOneBased()), "i/BensonM88", "i/CarlK77");
+        draftCommand = new DraftCommand(identifiers);
+        expected = DraftCommand.class.getCanonicalName() + "{identifiers=" + identifiers + "}";
         assertEquals(expected, draftCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/StatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StatsCommandTest.java
@@ -13,14 +13,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_KILLS_SET_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATS_SET_1;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.StatsCommand.EditStatsDescriptor;
 import seedu.address.model.AddressBook;
@@ -38,7 +35,7 @@ public class StatsCommandTest {
 
     @Test
     public void execute_statisticsSpecifiedUnfilteredList_success() {
-        Person firstPerson = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getAddressBook().getPersonList().get(0);
         Person editedPerson = new PersonBuilder(firstPerson).withEntityStatistics(VALID_ENTITY_STATISTIC_MAP).build();
         EditStatsDescriptor descriptor = new EditStatsDescriptorBuilder()
                 .withEntity(VALID_ENTITY_1)
@@ -46,7 +43,7 @@ public class StatsCommandTest {
                 .withDeaths(VALID_DEATHS_SET_1)
                 .withAssists(VALID_ASSISTS_SET_1)
                 .build();
-        StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
+        StatsCommand statsCommand = new StatsCommand("1", descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
         expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
@@ -59,7 +56,7 @@ public class StatsCommandTest {
 
     @Test
     public void execute_statistics_personWithoutExistingEntityEntry() {
-        Person firstPerson = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getAddressBook().getPersonList().get(0);
         Person emptyEntityMapPerson = new PersonBuilder(firstPerson)
             .withEntityStatistics(new EntityStatisticMap()).build();
         model.setPerson(firstPerson, emptyEntityMapPerson); //reset's first person's entity statistic map to be empty
@@ -71,7 +68,7 @@ public class StatsCommandTest {
                 .withDeaths(VALID_DEATHS_SET_1)
                 .withAssists(VALID_ASSISTS_SET_1)
                 .build();
-        StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
+        StatsCommand statsCommand = new StatsCommand("1", descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
         expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
@@ -84,7 +81,7 @@ public class StatsCommandTest {
 
     @Test
     public void execute_statistics_personWithExistingEntityEntry() {
-        Person firstPerson = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getAddressBook().getPersonList().get(0);
         Person filledEntityMapPerson = new PersonBuilder(firstPerson)
             .withEntityStatistics(VALID_ENTITY_STATISTIC_MAP).build();
         model.setPerson(firstPerson, filledEntityMapPerson);
@@ -100,7 +97,7 @@ public class StatsCommandTest {
                 .withDeaths(VALID_DEATHS_SET_1)
                 .withAssists(VALID_ASSISTS_SET_1)
                 .build();
-        StatsCommand statsCommand = new StatsCommand(INDEX_FIRST_PERSON, descriptor);
+        StatsCommand statsCommand = new StatsCommand("1", descriptor);
 
         String expectedMessage = String.format(StatsCommand.MESSAGE_STATS_SUCCESS, Messages.format(editedPerson));
         expectedMessage += "\n" + Messages.MESSAGE_GLOBAL_INDEX_COMMAND_CUE;
@@ -113,25 +110,25 @@ public class StatsCommandTest {
 
     @Test
     public void equals() {
-        final StatsCommand statsFirstCommand = new StatsCommand(INDEX_FIRST_PERSON, STATS_DESC_SET_1);
+        final StatsCommand statsFirstCommand = new StatsCommand("1", STATS_DESC_SET_1);
 
         // same values -> returns true
-        StatsCommand statsFirstCommandCopy = new StatsCommand(INDEX_FIRST_PERSON, STATS_DESC_SET_1);
+        StatsCommand statsFirstCommandCopy = new StatsCommand("1", STATS_DESC_SET_1);
         Assertions.assertTrue(statsFirstCommand.equals(statsFirstCommandCopy));
 
         // different index -> returns false
         Assertions.assertFalse(statsFirstCommand
-            .equals(new StatsCommand(INDEX_SECOND_PERSON, STATS_DESC_SET_1)));
+            .equals(new StatsCommand("2", STATS_DESC_SET_1)));
 
         // different descriptor -> returns false
         EditStatsDescriptor differentDescriptor = new EditStatsDescriptorBuilder()
             .withEntity(VALID_ENTITY_1).withKills("999").build();
         Assertions.assertFalse(statsFirstCommand
-            .equals(new StatsCommand(INDEX_FIRST_PERSON, differentDescriptor)));
+            .equals(new StatsCommand("1", differentDescriptor)));
     }
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getAddressBook().getPersonList().size() + 1);
+        String outOfBoundIndex = String.valueOf(model.getAddressBook().getPersonList().size() + 1);
         EditStatsDescriptor descriptor = new EditStatsDescriptorBuilder()
                 .withEntity(VALID_ENTITY_1)
                 .withKills(VALID_KILLS_SET_1)

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -103,7 +103,7 @@ public class AddressBookParserTest {
                 + INDEX_FIRST_PERSON.getOneBased() + " "
                 + PREFIX_ENTITY + VALID_ENTITY_NAME_1 + " "
                 + PREFIX_KILLS + kills);
-        assertEquals(new StatsCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new StatsCommand("1", descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CompareCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompareCommandParserTest.java
@@ -24,9 +24,9 @@ public class CompareCommandParserTest {
         // Test with indices
         assertParseSuccess(parser, "1 2", new CompareCommand("1", "2"));
         // Test with IGNs
-        assertParseSuccess(parser, "i/Player1 i/Player2", new CompareCommand("Player1", "Player2"));
+        assertParseSuccess(parser, "i/Player1 i/Player2", new CompareCommand("i/Player1", "i/Player2"));
         // Test with mixed identifiers
-        assertParseSuccess(parser, "1 i/Player2", new CompareCommand("1", "Player2"));
+        assertParseSuccess(parser, "1 i/Player2", new CompareCommand("1", "i/Player2"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -24,7 +24,7 @@ public class DeleteCommandParserTest {
         // Test with index
         assertParseSuccess(parser, "1", new DeleteCommand("1"));
         // Test with IGN
-        assertParseSuccess(parser, "i/PlayerName", new DeleteCommand("PlayerName"));
+        assertParseSuccess(parser, "i/PlayerName", new DeleteCommand("i/PlayerName"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DraftCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DraftCommandParserTest.java
@@ -5,12 +5,7 @@ import static seedu.address.logic.commands.DraftCommand.MESSAGE_INVALID_IGN_EMPT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_IGN;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_IDENTIFIER;
 
 import java.util.List;
 
@@ -42,12 +37,7 @@ public class DraftCommandParserTest {
 
     @Test
     public void parse_validIndexArgs_success() {
-        DraftCommand expectedCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_SECOND_PERSON,
-                INDEX_THIRD_PERSON,
-                INDEX_FOURTH_PERSON,
-                INDEX_FIFTH_PERSON), List.of());
+        DraftCommand expectedCommand = new DraftCommand(List.of("1", "2", "3", "4", "5"));
 
         assertParseSuccess(parser, "1 2 3 4 5", expectedCommand);
         assertParseSuccess(parser, "  1   2  3  4   5  ", expectedCommand);
@@ -55,8 +45,8 @@ public class DraftCommandParserTest {
 
     @Test
     public void parse_validIgnArgs_success() {
-        DraftCommand expectedCommand = new DraftCommand(List.of(),
-                List.of("AliceP99", "BensonM88", "CarlK77", "DanielM66", "ElleM55"));
+        DraftCommand expectedCommand = new DraftCommand(List.of(
+                "i/AliceP99", "i/BensonM88", "i/CarlK77", "i/DanielM66", "i/ElleM55"));
 
         assertParseSuccess(parser, buildIgnCommand("AliceP99", "BensonM88", "CarlK77", "DanielM66", "ElleM55"),
                 expectedCommand);
@@ -65,9 +55,7 @@ public class DraftCommandParserTest {
     @Test
     public void parse_validHybridArgs_success() {
         DraftCommand expectedCommand = new DraftCommand(List.of(
-                INDEX_FIRST_PERSON,
-                INDEX_THIRD_PERSON),
-                List.of("BensonM88", "DanielM66", "ElleM55"));
+                "1", "i/BensonM88", "i/DanielM66", "i/ElleM55", "3"));
 
         assertParseSuccess(parser,
                 "1 " + buildIgnCommand("BensonM88", "DanielM66", "ElleM55") + " 3",
@@ -82,7 +70,7 @@ public class DraftCommandParserTest {
 
     @Test
     public void parse_invalidIndex_failure() {
-        assertParseFailure(parser, "0", MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "0", MESSAGE_INVALID_IDENTIFIER);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/StatsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StatsCommandParserTest.java
@@ -12,11 +12,9 @@ import static seedu.address.logic.commands.CommandTestUtil.KILLS_DESC_SET_1;
 import static seedu.address.logic.commands.CommandTestUtil.STATS_DESC_SET_1;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StatsCommand;
 import seedu.address.model.entity.Entity;
 import seedu.address.model.person.statistics.Assists;
@@ -50,11 +48,8 @@ public class StatsCommandParserTest {
         // zero index
         assertParseFailure(parser, "0" + KILLS_DESC_SET_1, MESSAGE_INVALID_FORMAT);
 
-        // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
-
-        // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        // non-numeric without i/ prefix
+        assertParseFailure(parser, "abc" + KILLS_DESC_SET_1, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -71,11 +66,10 @@ public class StatsCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + " " + ENTITY_DESC_1 + " "
+        String userInput = "1 " + ENTITY_DESC_1 + " "
             + KILLS_DESC_SET_1 + DEATHS_DESC_SET_1 + ASSISTS_DESC_SET_1;
 
-        StatsCommand expectedCommand = new StatsCommand(targetIndex, STATS_DESC_SET_1);
+        StatsCommand expectedCommand = new StatsCommand("1", STATS_DESC_SET_1);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
Closes #184
Closes #188 
Closes #190
Closes #203
Closes #213
Closes #215
Closes #266

Changes all commands to support Index | IGN.

IGN _must_ use the `i/` prefix now. The draft command has been changed to do this.