### PR TITLE
Fix DraftCommandParser on error

### DIFF
--- a/src/main/java/seedu/address/logic/CommandUtil.java
+++ b/src/main/java/seedu/address/logic/CommandUtil.java
@@ -10,6 +10,8 @@ import seedu.address.model.person.Person;
  */
 public class CommandUtil {
 
+    public static final String MESSAGE_IGN_NOT_FOUND = "Player with IGN '%1$s' not found";
+
     /**
      * Finds a person in the address book by either index or IGN.
      *
@@ -27,7 +29,7 @@ public class CommandUtil {
                     return person;
                 }
             }
-            throw new CommandException(String.format("Player with IGN '%1$s' not found", ign));
+            throw new CommandException(String.format(MESSAGE_IGN_NOT_FOUND, ign));
         }
 
         // Check if identifier is an index (numeric)
@@ -45,6 +47,6 @@ public class CommandUtil {
                 return person;
             }
         }
-        throw new CommandException(String.format("Player with IGN '%1$s' not found", identifier));
+        throw new CommandException(String.format(MESSAGE_IGN_NOT_FOUND, identifier));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DraftCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DraftCommand.java
@@ -33,8 +33,6 @@ public class DraftCommand extends Command {
     public static final String EXAMPLE = "Example: " + COMMAND_WORD + " 1 2 i/CarlK77 4 i/ElleM55";
 
     public static final String MESSAGE_SUCCESS = "Draft validation complete: %1$s";
-    public static final String MESSAGE_INVALID_IGN_NOT_FOUND = "Player with IGN '%1$s' not found";
-    public static final String MESSAGE_INVALID_IGN_EMPTY = "IGN cannot be empty. Use format: i/playername";
     public static final String MESSAGE_INVALID_TEAM_SIZE = "Draft requires exactly 5 players. You provided %1$d";
     public static final String MESSAGE_DUPLICATE_PLAYER = "Duplicate player selected: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/DraftCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DraftCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.DraftCommand.MESSAGE_INVALID_IGN_EMPTY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IGN;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,33 +22,25 @@ public class DraftCommandParser implements Parser<DraftCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DraftCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DraftCommand.PARAMETERS));
-        }
-
-        String[] argStrings = trimmedArgs.split("\\s+");
-        List<String> identifiers = new ArrayList<>();
-        String prefix = PREFIX_IGN.getPrefix();
-
-        for (String argString : argStrings) {
-            // Handle i/ prefix: validate non-empty, then keep prefix intact
-            if (argString.startsWith(prefix)) {
-                String ign = argString.substring(prefix.length());
-                if (ign.isEmpty()) {
-                    throw new ParseException(MESSAGE_INVALID_IGN_EMPTY);
-                }
-                identifiers.add(argString); // Keep i/ prefix intact
-            } else if (argString.matches("\\d+")) {
-                // Numeric index
-                identifiers.add(ParserUtil.parseIdentifier(argString));
-            } else {
+        try {
+            String trimmedArgs = args.trim();
+            if (trimmedArgs.isEmpty()) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, DraftCommand.PARAMETERS));
             }
-        }
 
-        return new DraftCommand(identifiers);
+            String[] argStrings = trimmedArgs.split("\\s+");
+            List<String> identifiers = new ArrayList<>();
+
+            for (String argString : argStrings) {
+                String identifier = ParserUtil.parseIdentifier(argString);
+                identifiers.add(identifier);
+            }
+
+            return new DraftCommand(identifiers);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DraftCommand.PARAMETERS), pe);
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DraftCommandTest.java
@@ -3,11 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.CommandUtil.MESSAGE_IGN_NOT_FOUND;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.DraftCommand.MESSAGE_DUPLICATE_PLAYER;
-import static seedu.address.logic.commands.DraftCommand.MESSAGE_INVALID_IGN_NOT_FOUND;
 import static seedu.address.logic.commands.DraftCommand.MESSAGE_INVALID_TEAM_SIZE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -112,7 +112,7 @@ public class DraftCommandTest {
         DraftCommand draftCommand = new DraftCommand(List.of(invalidIgn));
 
         assertCommandFailure(draftCommand, model,
-                String.format(MESSAGE_INVALID_IGN_NOT_FOUND, "InvalidName"));
+                String.format(MESSAGE_IGN_NOT_FOUND, "InvalidName"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DraftCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DraftCommandParserTest.java
@@ -1,11 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.DraftCommand.MESSAGE_INVALID_IGN_EMPTY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_IGN;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_IDENTIFIER;
 
 import java.util.List;
 
@@ -70,11 +68,11 @@ public class DraftCommandParserTest {
 
     @Test
     public void parse_invalidIndex_failure() {
-        assertParseFailure(parser, "0", MESSAGE_INVALID_IDENTIFIER);
+        assertParseFailure(parser, "0", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_emptyIgn_failure() {
-        assertParseFailure(parser, PREFIX_IGN.getPrefix(), MESSAGE_INVALID_IGN_EMPTY);
+        assertParseFailure(parser, PREFIX_IGN.getPrefix(), MESSAGE_INVALID_FORMAT);
     }
 }


### PR DESCRIPTION
On invalid index error, fix error message to correctly show error message similar to `compare`/`delete` command
```
Invalid command format! 
Parameters: (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN) (INDEX | i/IGN)
```

instead of 
```
Invalid identifier. Must be either a global positive integer index shown beside a player in the list or an IGN prefixed with 'i/' (e.g., i/PlayerName).
```

Update test case for `DraftCommandParser`  as `MESSAGE_IGN_NOT_FOUND` is never used in the functional code, but passes test cases because its using the same string thrown as the `CommandUtil.findPersonByIdentifier`
Add `MESSAGE_IGN_NOT_FOUND` to `CommandUtil` to use in test case for `DraftCommandParser`